### PR TITLE
Restore space before "Regular" font name suffix

### DIFF
--- a/cpp/src/sample/chromium/subsetter_impl.cc
+++ b/cpp/src/sample/chromium/subsetter_impl.cc
@@ -133,7 +133,7 @@ bool HasName(const char* font_name, Font* font) {
   UCharString font_string = ConvertFromUtf8(font_name);
   if (font_string.empty())
     return false;
-  UCharString regular_suffix = ConvertFromUtf8("Regular");
+  UCharString regular_suffix = ConvertFromUtf8(" Regular");
   UCharString alt_font_string = font_string;
   alt_font_string += regular_suffix;
 


### PR DESCRIPTION
This will revert to earlier behavior of HasName, by including a space when appending "Regular" to a base font name to synthesize a possible full name. (The space appears to have been inadvertently dropped during the migration to UCharString.)